### PR TITLE
Fix TFTP data transfers on 127.0.0.1

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -9,7 +9,4 @@ services:
       - type: bind
         source: ./data
         target: /var/tftpboot
-    ports:
-      - protocol: udp
-        published: 69
-        target: 69
+    network_mode: host  # Allows TFTP data transfers on 127.0.0.1.


### PR DESCRIPTION
TFTP data transfers on 127.0.0.1 are broken: TFTP server responds from random UDP port and this behavior is not supported by docker-proxy.

```
client [127.0.0.1:48391] -> docker-proxy [127.0.0.1:69]: TFTP RRQ
docker-proxy [172.22.0.1:37665] -> server [172.22.0.2:69]: TFTP RRQ
server [172.18.0.2:39088] -> docker-proxy [127.0.0.1:37665]: TFTP DATA
host [172.22.0.1] -> server [127.22.0.2]: ICMP: 172.22.0.1 UDP port 37665 unreachable
```

The described issue is fixed by configuring container to use host network stack instead of bridge network and docker-proxy.