### PR TITLE
Set project name explicitly

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,4 @@
+name: netlab-tftp-service
 services:
   tftp:
     image: pghalliday/tftp@sha256:59f843a93d62ac6e2fa475ee3d1a3786464fe5ea0334e6f1ea79bdec837f09fa


### PR DESCRIPTION
This change allows to use symlinks to the project:

```sh
project_directory="$(pwd)"
ln -s "${project_directory}" /tmp/foo
cd /tmp/foo
docker compose up -d
```
